### PR TITLE
Image can be pulled from enrise/gcloudtoolbox:latest

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ stages:
 
 deploy to production:
     stage: deploy
-    image: gitlab.enrise.com:5005/enrise/gcloudkubebox:latest
+    image: enrise/gcloudtoolbox:latest
     environment:
         name: production
         url: https://example.com


### PR DESCRIPTION
### What

Image can be pulled from enrise/gcloudtoolbox:latest


### ToDo

- [x] Make the image available on hub.docker.com